### PR TITLE
Experimental/safe test parameters from excel files

### DIFF
--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -10,6 +10,7 @@ import microsim.statistics.regression.*;
 import org.apache.commons.io.FileUtils;
 import simpaths.data.startingpop.DataParser;
 import simpaths.model.AnnuityRates;
+import simpaths.model.BenefitUnit;
 import simpaths.model.Person;
 import simpaths.model.enums.*;
 import org.apache.commons.collections4.keyvalue.MultiKey;
@@ -3233,7 +3234,7 @@ public class Parameters {
         EUROMOD_TRAINING_DIRECTORY = EUROMOD_OUTPUT_DIRECTORY + "training" + File.separator;
     }
 
-    public static void validateRegressors(MultiKeyCoefficientMap map, String mapName) {
+    public static void validatePersonRegressors(MultiKeyCoefficientMap map, String excelFileName, String sheetName) {
         if (map == null) return;
 
         // Get the values read from the REGRESSOR column by ExcelAssistant (excludes 'Constant')
@@ -3248,10 +3249,15 @@ public class Parameters {
                 try {
                     Person.DoublesVariables.valueOf(keyName);
                 } catch (IllegalArgumentException e) {
-                    // This fires if the string isn't in the Enum
-                    throw new RuntimeException("Validation failed for " + mapName +
-                            ": Regressor '" + keyName + "' not found in Person.DoublesVariables. " +
-                            "Check for typos in Excel or missing Enums in Person.java.");
+                    try {
+                        BenefitUnit.Regressors.valueOf(keyName);
+                    } catch (IllegalArgumentException e2) {
+
+                        // This fires if the string isn't in the Enum
+                        throw new RuntimeException("Validation failed for " + excelFileName + " in " + sheetName +
+                                ": Regressor '" + keyName + "' not found in Person.DoublesVariables. " +
+                                "Check for typos in Excel or missing Enums in Person.java.");
+                    }
                 }
             }
         }
@@ -3261,7 +3267,7 @@ public class Parameters {
 
         MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns);
 
-        validateRegressors(map, sheetName);
+        validatePersonRegressors(map, excelFileName,  sheetName);
 
         return map;
 
@@ -3271,7 +3277,7 @@ public class Parameters {
 
         MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns, valueColumns);
 
-        validateRegressors(map, sheetName);
+        validatePersonRegressors(map, excelFileName, sheetName);
 
         return map;
 

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -1140,7 +1140,7 @@ public class Parameters {
         coeffCovarianceHM2CaseMales = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_mental.xlsx", countryString + "_HM2_Males_C", 1);
         coeffCovarianceHM2CaseFemales = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_mental.xlsx", countryString + "_HM2_Females_C", 1);
 
-        validateRegressors(coeffCovarianceHM2CaseMales, "HM2_Males_C");
+        validateRegressors(coeffCovarianceHM2CaseMales, "reg_health_mental.xlsx", "HM2_Males_C");
 
         //Health
         coeffCovarianceDHE_MCS1 = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_wellbeing.xlsx", countryString + "_DHE_MCS1", 1);
@@ -3234,7 +3234,7 @@ public class Parameters {
         EUROMOD_TRAINING_DIRECTORY = EUROMOD_OUTPUT_DIRECTORY + "training" + File.separator;
     }
 
-    public static void validatePersonRegressors(MultiKeyCoefficientMap map, String excelFileName, String sheetName) {
+    public static void validateRegressors(MultiKeyCoefficientMap map, String excelFileName, String sheetName) {
         if (map == null) return;
 
         // Get the values read from the REGRESSOR column by ExcelAssistant (excludes 'Constant')
@@ -3267,7 +3267,7 @@ public class Parameters {
 
         MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns);
 
-        validatePersonRegressors(map, excelFileName,  sheetName);
+        validateRegressors(map, excelFileName,  sheetName);
 
         return map;
 
@@ -3277,7 +3277,7 @@ public class Parameters {
 
         MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns, valueColumns);
 
-        validatePersonRegressors(map, excelFileName, sheetName);
+        validateRegressors(map, excelFileName, sheetName);
 
         return map;
 

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -10,6 +10,7 @@ import microsim.statistics.regression.*;
 import org.apache.commons.io.FileUtils;
 import simpaths.data.startingpop.DataParser;
 import simpaths.model.AnnuityRates;
+import simpaths.model.Person;
 import simpaths.model.enums.*;
 import org.apache.commons.collections4.keyvalue.MultiKey;
 import org.apache.commons.collections4.map.LinkedMap;
@@ -1137,6 +1138,8 @@ public class Parameters {
         coeffCovarianceHM1Case = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_mental.xlsx", countryString + "_HM1_C", 1);
         coeffCovarianceHM2CaseMales = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_mental.xlsx", countryString + "_HM2_Males_C", 1);
         coeffCovarianceHM2CaseFemales = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_mental.xlsx", countryString + "_HM2_Females_C", 1);
+
+        validateRegressors(coeffCovarianceHM2CaseMales, "HM2_Males_C");
 
         //Health
         coeffCovarianceDHE_MCS1 = ExcelAssistant.loadCoefficientMap(Parameters.getInputDirectory() + "reg_health_wellbeing.xlsx", countryString + "_DHE_MCS1", 1);
@@ -3228,6 +3231,30 @@ public class Parameters {
             EUROMOD_OUTPUT_DIRECTORY = WORKING_DIRECTORY + File.separator + euromodOutputDirectory + File.separator;
         }
         EUROMOD_TRAINING_DIRECTORY = EUROMOD_OUTPUT_DIRECTORY + "training" + File.separator;
+    }
+
+    public static void validateRegressors(MultiKeyCoefficientMap map, String mapName) {
+        if (map == null) return;
+
+        // Get the values read from the REGRESSOR column by ExcelAssistant (excludes 'Constant')
+        Set<Object> regressorNames = map.keySet();
+
+        // Check across all
+        for (Object regressor : regressorNames) {
+            if (regressor instanceof MultiKey mk) {
+                String keyName = mk.getKey(0).toString();
+
+                // Test if a Person Enum
+                try {
+                    Person.DoublesVariables.valueOf(keyName);
+                } catch (IllegalArgumentException e) {
+                    // This fires if the string isn't in the Enum
+                    throw new RuntimeException("Validation failed for " + mapName +
+                            ": Regressor '" + keyName + "' not found in Person.DoublesVariables. " +
+                            "Check for typos in Excel or missing Enums in Person.java.");
+                }
+            }
+        }
     }
 
     public static String getInputDirectory() {

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -3257,6 +3257,26 @@ public class Parameters {
         }
     }
 
+    public static MultiKeyCoefficientMap safeReadExcel(String excelFileName, String sheetName, int keyColumns) {
+
+        MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns);
+
+        validateRegressors(map, sheetName);
+
+        return map;
+
+    }
+
+    public static MultiKeyCoefficientMap safeReadExcel(String excelFileName, String sheetName, int keyColumns, int valueColumns) {
+
+        MultiKeyCoefficientMap map = ExcelAssistant.loadCoefficientMap(excelFileName, sheetName, keyColumns, valueColumns);
+
+        validateRegressors(map, sheetName);
+
+        return map;
+
+    }
+
     public static String getInputDirectory() {
         return INPUT_DIRECTORY;
     }

--- a/src/test/java/simpaths/data/ParametersTest.java
+++ b/src/test/java/simpaths/data/ParametersTest.java
@@ -1,0 +1,32 @@
+package simpaths.data;
+
+import microsim.data.MultiKeyCoefficientMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParametersTest {
+
+    /**
+     * Tests regressor validation logic using valid/invalid maps
+     */
+    @Test
+    void validateRegressors() {
+
+        String[] badValueVector = new String[] {"Dag", "Not_a_valid_value"};
+        String[] goodValueVector = new String[] {"Dag", "D_Home_owner", "PovertyToNonPoverty"};
+        String[] keyVector = new String[] {"REGRESSOR"};
+
+        MultiKeyCoefficientMap badMap = new MultiKeyCoefficientMap(keyVector, badValueVector);
+        for (String badValue : badValueVector) {badMap.putValue(badValue, 0);}
+
+        MultiKeyCoefficientMap goodMap = new MultiKeyCoefficientMap(keyVector, goodValueVector);
+        for (String goodValue : goodValueVector) {goodMap.putValue(goodValue, 0);}
+
+        assertThrows(RuntimeException.class, () -> Parameters.validateRegressors(badMap, "A map designed to contain invalid values"));
+        assertDoesNotThrow(() -> Parameters.validateRegressors(goodMap, "A map designed to contain valid values"));
+
+    }
+}

--- a/src/test/java/simpaths/data/ParametersTest.java
+++ b/src/test/java/simpaths/data/ParametersTest.java
@@ -25,8 +25,8 @@ class ParametersTest {
         MultiKeyCoefficientMap goodMap = new MultiKeyCoefficientMap(keyVector, goodValueVector);
         for (String goodValue : goodValueVector) {goodMap.putValue(goodValue, 0);}
 
-        assertThrows(RuntimeException.class, () -> Parameters.validateRegressors(badMap, "A map designed to contain invalid values"));
-        assertDoesNotThrow(() -> Parameters.validateRegressors(goodMap, "A map designed to contain valid values"));
+        assertThrows(RuntimeException.class, () -> Parameters.validateRegressors(badMap, "A map designed to contain invalid values", "Sheet1"));
+        assertDoesNotThrow(() -> Parameters.validateRegressors(goodMap, "A map designed to contain valid values", "Sheet1"));
 
     }
 }


### PR DESCRIPTION
# What

- A proposed potential 'safety test' of regressors as files are read-in

# Why

- When reading in a regression file which should contain findable enums this should check that they all load at the very start of the model running
- Otherwise it will crash much later with non-traceable messages
- So this would save time and prompt user to check specified row/columns in reg sheets before proceeding with any part of the run

# Before merging

- sense-check whether this is a good change and whether the `safeReadExcel` wrapper should replace all `ExcelAssistant.loadCoefficientMap` reads for all regression files?