### PR TITLE
run tests against dev version of jasmine core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>com.github.jasmineRepo</groupId>
 			<artifactId>JAS-mine-core</artifactId>
-            <version>5.1.0</version>
+            <version>8dd7543389a82fb9a70c62bb8625a4cdd5b4a7bf</version> <!--JASMINE-->
 			<scope>compile</scope>
 		</dependency>
 		<!-- Modern replacement for xmlParserAPIs -->

--- a/update-jasmine-test.sh
+++ b/update-jasmine-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# usually develop
+ON_BRANCH="develop"
+
+git switch --quiet ${ON_BRANCH} || exit
+git pull --quiet || exit
+git switch --quiet am/against-jasmine-dev || exit
+git rebase --quiet ${ON_BRANCH} || exit
+git -C ../JAS-mine-core show --no-patch || exit
+HASH=$(git -C ../JAS-mine-core rev-parse HEAD)
+sed -i "s|^            <version>.*</version> <!--JASMINE-->$|            <version>${HASH}</version> <!--JASMINE-->|" pom.xml
+echo
+git diff
+git commit --quiet -a --amend --no-edit


### PR DESCRIPTION
This PR is not for merging.

It provides a way to test `SimPaths` against the development version of `JAS-mine-core`.